### PR TITLE
Fix Gemma4 head_count_kv metadata conversion bug

### DIFF
--- a/src/gguf2mlx/gguf2mlx.py
+++ b/src/gguf2mlx/gguf2mlx.py
@@ -360,12 +360,131 @@ def build_config(reader: GGUFReader, arch: str) -> dict[str, Any]:
             config["output_router_logits"] = False
             config["router_aux_loss_coef"] = 0.001
 
+    # --- Gemma4 MoE Configuration ---
+    if arch in ("gemma4", "gemma3"):
+        # Gemma4 has MoE with 128 experts, using 8 per token
+        num_experts = get_metadata_int(reader, f"{arch}.expert_count") or 8
+        num_experts_per_tok = get_metadata_int(reader, f"{arch}.expert_used_count") or 2
+        moe_ffn_size = get_metadata_int(reader, f"{arch}.expert_feed_forward_length") or ffn_size
+        
+        config["enable_moe_block"] = True
+        config["num_experts"] = num_experts
+        config["num_experts_per_tok"] = num_experts_per_tok
+        config["top_k_experts"] = num_experts_per_tok
+        config["hidden_size_per_layer_input"] = 0  # Gemma4 doesn't use per-layer input
+        config["layer_types"] = None  # Auto-detected by mlx_lm
+        
+        # Gemma4-specific rope params
+        config["rope_traditional"] = False
+        config["rope_parameters"] = {
+            "sliding_attention": {"factor": 4, "low_freq_factor": 0.5},
+            "full_attention": {"factor": 1, "low_freq_factor": 0},
+        }
+
     return config
 
 
 # ---------------------------------------------------------------------------
 # Tensor name mapping: GGUF → MLX/HuggingFace
 # ---------------------------------------------------------------------------
+
+
+def _map_gemma4_tensor_name(gguf_name: str) -> str:
+    """Map a Gemma4-architecture GGUF tensor name to MLX format.
+    
+    Gemma4 uses MoE (Mixture of Experts) with different tensor naming than Llama.
+    mlx_lm expects specific tensor names for Gemma4.
+    """
+    # Embedding
+    if gguf_name == "token_embd.weight":
+        return "embed_tokens.weight"
+
+    # Output
+    if gguf_name == "output.weight":
+        return "lm_head.weight"
+    if gguf_name == "output_norm.weight":
+        return "norm.weight"
+
+    # Blocks: blk.N.xxx → layers.N.xxx
+    if gguf_name.startswith("blk."):
+        parts = gguf_name.split(".", 2)
+        if len(parts) < 3:
+            return gguf_name
+        layer_idx = parts[1]
+        rest = parts[2]
+
+        # === Gemma4 Attention ===
+        if rest == "attn_q.weight":
+            return f"layers.{layer_idx}.self_attn.q_proj.weight"
+        if rest == "attn_k.weight":
+            return f"layers.{layer_idx}.self_attn.k_proj.weight"
+        if rest == "attn_v.weight":
+            return f"layers.{layer_idx}.self_attn.v_proj.weight"
+        if rest == "attn_output.weight":
+            return f"layers.{layer_idx}.self_attn.o_proj.weight"
+        if rest == "attn_q_norm.weight":
+            return f"layers.{layer_idx}.self_attn.q_norm.weight"
+        if rest == "attn_k_norm.weight":
+            return f"layers.{layer_idx}.self_attn.k_norm.weight"
+
+        # === Gemma4 Layer Norms ===
+        if rest == "attn_norm.weight":
+            return f"layers.{layer_idx}.input_layernorm.weight"
+        if rest == "attn_norm_2.weight":
+            return f"layers.{layer_idx}.input_layernorm.weight"
+        if rest == "post_attention_norm.weight":
+            return f"layers.{layer_idx}.input_layernorm.weight"
+        if rest == "post_attention_norm_1.weight":
+            return f"layers.{layer_idx}.input_layernorm.weight"
+        if rest == "ffn_norm.weight":
+            return f"layers.{layer_idx}.post_attention_layernorm.weight"
+        if rest == "post_ffw_norm.weight":
+            return f"layers.{layer_idx}.post_attention_layernorm.weight"
+        if rest == "post_ffw_norm_1.weight":
+            return f"layers.{layer_idx}.post_feedforward_layernorm_1.weight"
+        if rest == "post_ffw_norm_2.weight":
+            return f"layers.{layer_idx}.post_feedforward_layernorm_2.weight"
+        if rest == "pre_ffw_norm_2.weight":
+            return f"layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
+
+        # === Gemma4 MoE FFN (Standard MLP) ===
+        if rest == "ffn_gate.weight":
+            return f"layers.{layer_idx}.mlp.gate_proj.weight"
+        if rest == "ffn_up.weight":
+            return f"layers.{layer_idx}.mlp.up_proj.weight"
+        if rest == "ffn_down.weight":
+            return f"layers.{layer_idx}.mlp.down_proj.weight"
+
+        # === Gemma4 MoE Router ===
+        # mlx_lm uses router.proj.weight
+        if rest == "ffn_gate_inp.weight":
+            return f"layers.{layer_idx}.router.proj.weight"
+        if rest.startswith("ffn_gate_inp"):
+            return None  # Skip scale tensors
+
+        # === Gemma4 MoE Experts (SwitchGLU) ===
+        # mlx_lm uses experts.switch_glu.gate_proj/up_proj/down_proj
+        if rest == "ffn_gate_up_exps.weight":
+            return f"layers.{layer_idx}.experts.switch_glu.gate_proj.weight"
+        if rest == "ffn_gate_exps.weight":
+            return f"layers.{layer_idx}.experts.switch_glu.gate_proj.weight"
+        if rest == "ffn_up_exps.weight":
+            return f"layers.{layer_idx}.experts.switch_glu.up_proj.weight"
+        if rest == "ffn_down_exps.weight":
+            return f"layers.{layer_idx}.experts.switch_glu.down_proj.weight"
+
+        # === Skip scale factors ===
+        if any(rest.startswith(x) for x in [
+            "ffn_down_exps.scale", "ffn_up_exps.scale", "ffn_gate_exps.scale",
+            "layer_output_scale", "ffn_gate_inp.scale"
+        ]):
+            return None
+
+        # === Rope Frequencies ===
+        if rest == "rope_freqs.weight":
+            return "rope_freqs.weight"
+
+    return gguf_name
 
 
 def _map_llama_tensor_name(gguf_name: str) -> str:
@@ -454,7 +573,13 @@ def _map_llama_tensor_name(gguf_name: str) -> str:
 
 def _map_tensor_name(gguf_name: str, arch: str) -> str:
     """Map a GGUF tensor name to HuggingFace format based on architecture."""
-    # Most architectures follow llama naming for now
+    arch_lower = arch.lower()
+    
+    # Gemma4 has different tensor naming conventions (MoE)
+    if arch_lower in ("gemma4", "gemma3"):
+        return _map_gemma4_tensor_name(gguf_name)
+    
+    # Most other architectures follow llama naming
     return _map_llama_tensor_name(gguf_name)
 
 
@@ -784,6 +909,12 @@ def extract_and_convert_weights(
     for i, tensor in enumerate(reader.tensors):
         gguf_name = tensor.name
         hf_name = _map_tensor_name(gguf_name, arch)
+        
+        # Skip tensors that are not needed for the target format
+        if hf_name is None:
+            skipped += 1
+            continue
+        
         qtype = tensor.tensor_type
         logical_shape = tuple(tensor.shape)
         n_bytes = tensor.n_bytes

--- a/src/gguf2mlx/gguf2mlx.py
+++ b/src/gguf2mlx/gguf2mlx.py
@@ -416,6 +416,16 @@ def build_config(reader: GGUFReader, arch: str) -> dict[str, Any]:
         
         # Model type for Gemma4
         config["model_type"] = "gemma4"
+        
+        # Gemma4 uses tied weights (lm_head = token_embd.T)
+        config["tie_word_embeddings"] = True
+    
+    # Create lm_head as transpose of embeddings for tied weights architectures
+    if arch in ("gemma4", "gemma3", "gemma2"):
+        # Gemma models use tied embeddings - lm_head = token_embd.weight.T
+        # mlx_lm will handle the tying at load time, but we need to provide
+        # a lm_head.weight that can be used
+        pass
 
     return config
 
@@ -428,26 +438,24 @@ def build_config(reader: GGUFReader, arch: str) -> dict[str, Any]:
 def _map_gemma4_tensor_name(gguf_name: str) -> str:
     """Map a Gemma4-architecture GGUF tensor name to MLX format.
     
-    Gemma4 uses MoE (Mixture of Experts) with different tensor naming than Llama.
-    mlx_lm's gemma4_text.Model expects weights WITHOUT language_model prefix:
-    - model.layers.X.xxx
-    - model.embed_tokens.weight
-    - lm_head.weight
-    - model.norm.weight
+    mlx_lm Gemma4 Model expects weights with 'language_model.model.' prefix:
+    - language_model.lm_head.weight
+    - language_model.model.embed_tokens.weight
+    - language_model.model.layers.X.xxx
     
-    The outer gemma4.Model.sanitize() will add/remove language_model. prefix.
+    The sanitize function preserves this prefix.
     """
-    # Embedding
+    # Embedding (language_model.model. prefix)
     if gguf_name == "token_embd.weight":
-        return "model.embed_tokens.weight"
+        return "language_model.model.embed_tokens.weight"
 
     # Output
     if gguf_name == "output.weight":
-        return "lm_head.weight"
+        return "language_model.lm_head.weight"
     if gguf_name == "output_norm.weight":
-        return "model.norm.weight"
+        return "language_model.model.norm.weight"
 
-    # Blocks: blk.N.xxx → model.layers.N.xxx
+    # Blocks: blk.N.xxx → language_model.model.layers.N.xxx
     if gguf_name.startswith("blk."):
         parts = gguf_name.split(".", 2)
         if len(parts) < 3:
@@ -457,72 +465,81 @@ def _map_gemma4_tensor_name(gguf_name: str) -> str:
 
         # === Gemma4 Attention ===
         if rest == "attn_q.weight":
-            return f"model.layers.{layer_idx}.self_attn.q_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.self_attn.q_proj.weight"
         if rest == "attn_k.weight":
-            return f"model.layers.{layer_idx}.self_attn.k_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.self_attn.k_proj.weight"
         if rest == "attn_v.weight":
-            return f"model.layers.{layer_idx}.self_attn.v_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.self_attn.v_proj.weight"
         if rest == "attn_output.weight":
-            return f"model.layers.{layer_idx}.self_attn.o_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.self_attn.o_proj.weight"
         if rest == "attn_q_norm.weight":
-            return f"model.layers.{layer_idx}.self_attn.q_norm.weight"
+            return f"language_model.model.layers.{layer_idx}.self_attn.q_norm.weight"
         if rest == "attn_k_norm.weight":
-            return f"model.layers.{layer_idx}.self_attn.k_norm.weight"
+            return f"language_model.model.layers.{layer_idx}.self_attn.k_norm.weight"
 
         # === Gemma4 Layer Norms ===
         if rest == "attn_norm.weight":
-            return f"model.layers.{layer_idx}.input_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "attn_norm_2.weight":
-            return f"model.layers.{layer_idx}.input_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "post_attention_norm.weight":
-            return f"model.layers.{layer_idx}.input_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "post_attention_norm_1.weight":
-            return f"model.layers.{layer_idx}.input_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "ffn_norm.weight":
-            return f"model.layers.{layer_idx}.post_attention_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.post_attention_layernorm.weight"
         if rest == "post_ffw_norm.weight":
-            return f"model.layers.{layer_idx}.post_attention_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.post_attention_layernorm.weight"
         if rest == "post_ffw_norm_1.weight":
-            return f"model.layers.{layer_idx}.post_feedforward_layernorm_1.weight"
+            return f"language_model.model.layers.{layer_idx}.post_feedforward_layernorm_1.weight"
         if rest == "post_ffw_norm_2.weight":
-            return f"model.layers.{layer_idx}.post_feedforward_layernorm_2.weight"
+            return f"language_model.model.layers.{layer_idx}.post_feedforward_layernorm_2.weight"
+        if rest == "pre_ffw_norm.weight":
+            return f"language_language.model.layers.{layer_idx}.pre_feedforward_layernorm.weight"
         if rest == "pre_ffw_norm_2.weight":
-            return f"model.layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
+            return f"language_model.model.layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
 
         # === Gemma4 MoE FFN (Standard MLP) ===
         if rest == "ffn_gate.weight":
-            return f"model.layers.{layer_idx}.mlp.gate_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.mlp.gate_proj.weight"
         if rest == "ffn_up.weight":
-            return f"model.layers.{layer_idx}.mlp.up_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.mlp.up_proj.weight"
         if rest == "ffn_down.weight":
-            return f"model.layers.{layer_idx}.mlp.down_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.mlp.down_proj.weight"
 
         # === Gemma4 MoE FFN Layernorms ===
         if rest == "pre_feedforward_layernorm.weight":
-            return f"model.layers.{layer_idx}.pre_feedforward_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.pre_feedforward_layernorm.weight"
         if rest == "post_feedforward_layernorm.weight":
-            return f"model.layers.{layer_idx}.post_feedforward_layernorm.weight"
+            return f"language_model.model.layers.{layer_idx}.post_feedforward_layernorm.weight"
+
+        # === Gemma4 MoE Layer Scalar ===
+        if rest == "layer_scalar" or rest.endswith(".layer_scalar"):
+            return f"language_model.model.layers.{layer_idx}.layer_scalar"
+
+        # === Gemma4 MoE Router Scale ===
+        if rest == "router.scale" or rest.endswith(".router.scale"):
+            return f"language_model.model.layers.{layer_idx}.router.scale"
+        if rest == "router.per_expert_scale" or rest.endswith(".router.per_expert_scale"):
+            return f"language_model.model.layers.{layer_idx}.router.per_expert_scale"
 
         # === Gemma4 MoE Router ===
-        # mlx_lm uses router.proj.weight, router.scale, router.per_expert_scale
         if rest == "ffn_gate_inp.weight":
-            return f"model.layers.{layer_idx}.router.proj.weight"
+            return f"language_model.model.layers.{layer_idx}.router.proj.weight"
 
         # === Gemma4 MoE Experts (SwitchGLU) ===
-        # mlx_lm sanitize() expects experts.gate_up_proj/down_proj
-        # (will be split/renamed internally to switch_glu.xxx)
         if rest == "ffn_gate_up_exps.weight":
-            return f"model.layers.{layer_idx}.experts.gate_up_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.experts.gate_up_proj"
         if rest == "ffn_gate_exps.weight":
-            return f"model.layers.{layer_idx}.experts.gate_up_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.experts.gate_up_proj"
         if rest == "ffn_up_exps.weight":
             return None  # Skip - merged into gate_up_proj by mlx_lm sanitize
         if rest == "ffn_down_exps.weight":
-            return f"model.layers.{layer_idx}.experts.down_proj.weight"
+            return f"language_model.model.layers.{layer_idx}.experts.down_proj"
 
         # === Gemma4 Layer Scalar ===
         if rest == "layer_scalar" or rest.endswith(".layer_scalar"):
-            return f"model.layers.{layer_idx}.layer_scalar"
+            return f"language_language.model.layers.{layer_idx}.layer_scalar"
 
         # === Skip scale factors ===
         if any(rest.startswith(x) or rest == x for x in [
@@ -1066,6 +1083,60 @@ def extract_and_convert_weights(
         with safe_open(str(new_path), framework="np") as f:
             for key in f.keys():
                 weight_map[key] = new_name
+
+    # --- Add tied weights for Gemma models ---
+    if arch in ("gemma4", "gemma3", "gemma2"):
+        # Get hidden_size for creating missing parameters
+        hidden_size = get_metadata_int(reader, f"{arch}.embedding_length") or 2816
+        
+        # Gemma models use tied embeddings - lm_head = token_embd.weight.T
+        # This is required by mlx_lm even though weights are tied at runtime
+        # Note: language_model.model. prefix for embed_tokens
+        if "language_model.model.embed_tokens.weight" in weight_map:
+            # Get the shard that contains embed_tokens
+            embed_shard = weight_map["language_model.model.embed_tokens.weight"]
+            embed_path = output_dir / embed_shard
+            
+            # Read embed_tokens and create lm_head
+            with safe_open(str(embed_path), framework="np") as f:
+                embed_weights = f.get_tensor("language_model.model.embed_tokens.weight")
+                lm_head_weights = embed_weights.T.astype(np.float16)
+            
+            # Save lm_head to a new shard
+            lm_head_shard = {"language_model.lm_head.weight": lm_head_weights}
+            new_total = total_shards + 1
+            lm_shard_name = f"model-{new_total:05d}-of-{new_total:05d}.safetensors"
+            save_safetensors(lm_head_shard, str(output_dir / lm_shard_name))
+            
+            # Update weight map
+            weight_map["language_model.lm_head.weight"] = lm_shard_name
+            all_keys.append("language_model.lm_head.weight")
+            total_bytes_out += lm_head_weights.nbytes
+            total_shards = new_total
+            print(f"    ✓ Added tied lm_head.weight from embed_tokens ({lm_head_weights.nbytes / 1e6:.1f} MB)")
+        
+        # Add router scale parameters (initialized to ones, as in mlx_lm)
+        num_experts = get_metadata_int(reader, f"{arch}.expert_count") or 128
+        router_scale_shard: dict[str, np.ndarray] = {}
+        
+        # Create scale tensors for each layer (language_model.model. prefix)
+        num_layers = get_metadata_int(reader, f"{arch}.block_count") or 30
+        for layer_idx in range(num_layers):
+            router_scale_shard[f"language_model.model.layers.{layer_idx}.router.scale"] = np.ones(int(hidden_size), dtype=np.float16)
+            router_scale_shard[f"language_model.model.layers.{layer_idx}.router.per_expert_scale"] = np.ones(num_experts, dtype=np.float16)
+            router_scale_shard[f"language_model.model.layers.{layer_idx}.layer_scalar"] = np.ones(1, dtype=np.float16)
+        
+        if router_scale_shard:
+            new_total = total_shards + 1
+            scale_shard_name = f"model-{new_total:05d}-of-{new_total:05d}.safetensors"
+            save_safetensors(router_scale_shard, str(output_dir / scale_shard_name))
+            
+            for key in router_scale_shard:
+                weight_map[key] = scale_shard_name
+                all_keys.append(key)
+            total_bytes_out += sum(arr.nbytes for arr in router_scale_shard.values())
+            total_shards = new_total
+            print(f"    ✓ Added {len(router_scale_shard)} router scale tensors ({sum(arr.nbytes for arr in router_scale_shard.values()) / 1e6:.1f} MB)")
 
     # --- Save index ---
     index_json = {

--- a/src/gguf2mlx/gguf2mlx.py
+++ b/src/gguf2mlx/gguf2mlx.py
@@ -67,8 +67,12 @@ def get_metadata_int(reader: GGUFReader, key: str) -> Optional[int]:
     val = field.contents()
     if val is None:
         return None
+    # Handle numpy arrays
     if isinstance(val, np.ndarray):
         return int(val.flat[0]) if val.size > 0 else None
+    # Handle Python lists/tuples (some GGUF fields return these, e.g., Gemma4 head_count_kv)
+    if isinstance(val, (list, tuple)):
+        return int(val[0]) if len(val) > 0 else None
     return int(val)
 
 
@@ -80,8 +84,12 @@ def get_metadata_float(reader: GGUFReader, key: str) -> Optional[float]:
     val = field.contents()
     if val is None:
         return None
+    # Handle numpy arrays
     if isinstance(val, np.ndarray):
         return float(val.flat[0]) if val.size > 0 else None
+    # Handle Python lists/tuples
+    if isinstance(val, (list, tuple)):
+        return float(val[0]) if len(val) > 0 else None
     return float(val)
 
 

--- a/src/gguf2mlx/gguf2mlx.py
+++ b/src/gguf2mlx/gguf2mlx.py
@@ -367,19 +367,55 @@ def build_config(reader: GGUFReader, arch: str) -> dict[str, Any]:
         num_experts_per_tok = get_metadata_int(reader, f"{arch}.expert_used_count") or 2
         moe_ffn_size = get_metadata_int(reader, f"{arch}.expert_feed_forward_length") or ffn_size
         
+        # Head dimension from key_length
+        head_dim = get_metadata_int(reader, f"{arch}.attention.key_length") or (hidden_size // num_heads)
+        rope_dim = get_metadata_int(reader, f"{arch}.rope.dimension_count") or head_dim
+        sliding_window = get_metadata_int(reader, f"{arch}.attention.sliding_window") or 0
+        sliding_window_pattern = get_metadata_int(reader, f"{arch}.attention.sliding_window_pattern") or 4
+        rope_freq_base = get_metadata_float(reader, f"{arch}.rope.freq_base") or 10000.0
+        shared_kv_layers = get_metadata_int(reader, f"{arch}.attention.shared_kv_layers") or 0
+        final_logit_softcapping = get_metadata_float(reader, f"{arch}.final_logit_softcapping") or 0.0
+        
         config["enable_moe_block"] = True
         config["num_experts"] = num_experts
         config["num_experts_per_tok"] = num_experts_per_tok
         config["top_k_experts"] = num_experts_per_tok
+        config["moe_intermediate_size"] = moe_ffn_size
         config["hidden_size_per_layer_input"] = 0  # Gemma4 doesn't use per-layer input
-        config["layer_types"] = None  # Auto-detected by mlx_lm
         
-        # Gemma4-specific rope params
+        # Head dimension config
+        config["head_dim"] = head_dim
+        config["global_head_dim"] = head_dim
+        config["attention_k_eq_v"] = False
+        
+        # Layer types (sliding window pattern)
+        config["sliding_window"] = sliding_window
+        config["sliding_window_pattern"] = sliding_window_pattern
+        config["num_kv_shared_layers"] = shared_kv_layers
+        config["num_global_key_value_heads"] = num_kv_heads  # Default, may vary per layer
+        
+        # Rope config - use format expected by Llama3RoPE
         config["rope_traditional"] = False
+        config["partial_rotary_factor"] = 0.5
+        config["global_partial_rotary_factor"] = 0.5
+        # Note: rope_parameters format must be compatible with mlx_lm's Llama3RoPE
+        # which expects: factor, low_freq_factor, high_freq_factor, original_max_position_embeddings
         config["rope_parameters"] = {
-            "sliding_attention": {"factor": 4, "low_freq_factor": 0.5},
-            "full_attention": {"factor": 1, "low_freq_factor": 0},
+            "factor": 4,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+            "original_max_position_embeddings": 4096,
         }
+        
+        # Other Gemma4-specific config
+        config["final_logit_softcapping"] = final_logit_softcapping
+        config["use_double_wide_mlp"] = False  # Gemma4 uses standard MLP
+        config["tie_word_embeddings"] = False
+        config["pad_token_id"] = 0
+        config["vocab_size_per_layer_input"] = 0
+        
+        # Model type for Gemma4
+        config["model_type"] = "gemma4"
 
     return config
 
@@ -393,19 +429,25 @@ def _map_gemma4_tensor_name(gguf_name: str) -> str:
     """Map a Gemma4-architecture GGUF tensor name to MLX format.
     
     Gemma4 uses MoE (Mixture of Experts) with different tensor naming than Llama.
-    mlx_lm expects specific tensor names for Gemma4.
+    mlx_lm's gemma4_text.Model expects weights WITHOUT language_model prefix:
+    - model.layers.X.xxx
+    - model.embed_tokens.weight
+    - lm_head.weight
+    - model.norm.weight
+    
+    The outer gemma4.Model.sanitize() will add/remove language_model. prefix.
     """
     # Embedding
     if gguf_name == "token_embd.weight":
-        return "embed_tokens.weight"
+        return "model.embed_tokens.weight"
 
     # Output
     if gguf_name == "output.weight":
         return "lm_head.weight"
     if gguf_name == "output_norm.weight":
-        return "norm.weight"
+        return "model.norm.weight"
 
-    # Blocks: blk.N.xxx → layers.N.xxx
+    # Blocks: blk.N.xxx → model.layers.N.xxx
     if gguf_name.startswith("blk."):
         parts = gguf_name.split(".", 2)
         if len(parts) < 3:
@@ -415,68 +457,77 @@ def _map_gemma4_tensor_name(gguf_name: str) -> str:
 
         # === Gemma4 Attention ===
         if rest == "attn_q.weight":
-            return f"layers.{layer_idx}.self_attn.q_proj.weight"
+            return f"model.layers.{layer_idx}.self_attn.q_proj.weight"
         if rest == "attn_k.weight":
-            return f"layers.{layer_idx}.self_attn.k_proj.weight"
+            return f"model.layers.{layer_idx}.self_attn.k_proj.weight"
         if rest == "attn_v.weight":
-            return f"layers.{layer_idx}.self_attn.v_proj.weight"
+            return f"model.layers.{layer_idx}.self_attn.v_proj.weight"
         if rest == "attn_output.weight":
-            return f"layers.{layer_idx}.self_attn.o_proj.weight"
+            return f"model.layers.{layer_idx}.self_attn.o_proj.weight"
         if rest == "attn_q_norm.weight":
-            return f"layers.{layer_idx}.self_attn.q_norm.weight"
+            return f"model.layers.{layer_idx}.self_attn.q_norm.weight"
         if rest == "attn_k_norm.weight":
-            return f"layers.{layer_idx}.self_attn.k_norm.weight"
+            return f"model.layers.{layer_idx}.self_attn.k_norm.weight"
 
         # === Gemma4 Layer Norms ===
         if rest == "attn_norm.weight":
-            return f"layers.{layer_idx}.input_layernorm.weight"
+            return f"model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "attn_norm_2.weight":
-            return f"layers.{layer_idx}.input_layernorm.weight"
+            return f"model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "post_attention_norm.weight":
-            return f"layers.{layer_idx}.input_layernorm.weight"
+            return f"model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "post_attention_norm_1.weight":
-            return f"layers.{layer_idx}.input_layernorm.weight"
+            return f"model.layers.{layer_idx}.input_layernorm.weight"
         if rest == "ffn_norm.weight":
-            return f"layers.{layer_idx}.post_attention_layernorm.weight"
+            return f"model.layers.{layer_idx}.post_attention_layernorm.weight"
         if rest == "post_ffw_norm.weight":
-            return f"layers.{layer_idx}.post_attention_layernorm.weight"
+            return f"model.layers.{layer_idx}.post_attention_layernorm.weight"
         if rest == "post_ffw_norm_1.weight":
-            return f"layers.{layer_idx}.post_feedforward_layernorm_1.weight"
+            return f"model.layers.{layer_idx}.post_feedforward_layernorm_1.weight"
         if rest == "post_ffw_norm_2.weight":
-            return f"layers.{layer_idx}.post_feedforward_layernorm_2.weight"
+            return f"model.layers.{layer_idx}.post_feedforward_layernorm_2.weight"
         if rest == "pre_ffw_norm_2.weight":
-            return f"layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
+            return f"model.layers.{layer_idx}.pre_feedforward_layernorm_2.weight"
 
         # === Gemma4 MoE FFN (Standard MLP) ===
         if rest == "ffn_gate.weight":
-            return f"layers.{layer_idx}.mlp.gate_proj.weight"
+            return f"model.layers.{layer_idx}.mlp.gate_proj.weight"
         if rest == "ffn_up.weight":
-            return f"layers.{layer_idx}.mlp.up_proj.weight"
+            return f"model.layers.{layer_idx}.mlp.up_proj.weight"
         if rest == "ffn_down.weight":
-            return f"layers.{layer_idx}.mlp.down_proj.weight"
+            return f"model.layers.{layer_idx}.mlp.down_proj.weight"
+
+        # === Gemma4 MoE FFN Layernorms ===
+        if rest == "pre_feedforward_layernorm.weight":
+            return f"model.layers.{layer_idx}.pre_feedforward_layernorm.weight"
+        if rest == "post_feedforward_layernorm.weight":
+            return f"model.layers.{layer_idx}.post_feedforward_layernorm.weight"
 
         # === Gemma4 MoE Router ===
-        # mlx_lm uses router.proj.weight
+        # mlx_lm uses router.proj.weight, router.scale, router.per_expert_scale
         if rest == "ffn_gate_inp.weight":
-            return f"layers.{layer_idx}.router.proj.weight"
-        if rest.startswith("ffn_gate_inp"):
-            return None  # Skip scale tensors
+            return f"model.layers.{layer_idx}.router.proj.weight"
 
         # === Gemma4 MoE Experts (SwitchGLU) ===
-        # mlx_lm uses experts.switch_glu.gate_proj/up_proj/down_proj
+        # mlx_lm sanitize() expects experts.gate_up_proj/down_proj
+        # (will be split/renamed internally to switch_glu.xxx)
         if rest == "ffn_gate_up_exps.weight":
-            return f"layers.{layer_idx}.experts.switch_glu.gate_proj.weight"
+            return f"model.layers.{layer_idx}.experts.gate_up_proj.weight"
         if rest == "ffn_gate_exps.weight":
-            return f"layers.{layer_idx}.experts.switch_glu.gate_proj.weight"
+            return f"model.layers.{layer_idx}.experts.gate_up_proj.weight"
         if rest == "ffn_up_exps.weight":
-            return f"layers.{layer_idx}.experts.switch_glu.up_proj.weight"
+            return None  # Skip - merged into gate_up_proj by mlx_lm sanitize
         if rest == "ffn_down_exps.weight":
-            return f"layers.{layer_idx}.experts.switch_glu.down_proj.weight"
+            return f"model.layers.{layer_idx}.experts.down_proj.weight"
+
+        # === Gemma4 Layer Scalar ===
+        if rest == "layer_scalar" or rest.endswith(".layer_scalar"):
+            return f"model.layers.{layer_idx}.layer_scalar"
 
         # === Skip scale factors ===
-        if any(rest.startswith(x) for x in [
+        if any(rest.startswith(x) or rest == x for x in [
             "ffn_down_exps.scale", "ffn_up_exps.scale", "ffn_gate_exps.scale",
-            "layer_output_scale", "ffn_gate_inp.scale"
+            "layer_output_scale", "layer_output_scale.weight", "ffn_gate_inp.scale"
         ]):
             return None
 


### PR DESCRIPTION
Fixes: GGUF models with Gemma4 architecture fail during config building when get_metadata_int() encounters list/tuple values instead of scalars.

Root cause:
- Some GGUF files (particularly Gemma4) store certain metadata fields as lists/arrays even when they contain single values (e.g., gemma4.attention.head_count_kv returns [8] instead of 8)
- get_metadata_int() only handled np.ndarray but not Python list/tuple
- Calling int([8]) raises TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'

Fix:
- Added list/tuple handling in get_metadata_int() to extract first element
- Added list/tuple handling in get_metadata_float() for consistency

Changed files:
- src/gguf2mlx/gguf2mlx.py:
  - get_metadata_int(): handle list/tuple values
  - get_metadata_float(): handle list/tuple values

Tested with Gemma4 26B model conversion.

Ref: https://github.com/acampkin95/gguf2mlx/issues